### PR TITLE
allow to change prefix, and define default values for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A dialect for Thymeleaf that enables reusable UI components with named slots and
 - Define reusable UI components
 - Support for default and named slots
 - Support for component parameters
+- Supports default values for component parameters
 - Simple integration with Thymeleaf into Spring
 
 ## Installation
@@ -57,9 +58,10 @@ When directly instantiating the template engine, set the component dialect using
 
 ```html
 <!-- src/main/resources/templates/components/card.html -->
-<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="card(title)">
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="card(title)" pl:subtitle="${null}">
   <div class="card">
     <div class="card-header" th:text="${title}">Card Title</div>
+    <div th:if="${subtitle}" class="card-subtitle" th:text="${subtitle}">Card Subtitle</div>
     <div class="card-body">
       <pl:slot>
         <!-- default slot -->
@@ -85,6 +87,10 @@ Do the same accordingly for the other components.
   <div pl:slot="footer">
     <b>This will replace the footer slot content</b>
   </div>
+</pl:card>
+
+<pl:card pl:title="My Card" pl:subtitle="My Subtitle">
+  <div>This will replace the default slot content</div>
 </pl:card>
 ```
 

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
@@ -22,20 +22,23 @@ import org.thymeleaf.processor.IProcessor;
 
 public class ComponentDialect extends AbstractProcessorDialect {
 
-  private static final String DIALECT_PREFIX = "pl";
+  private static final String DEFAULT_DIALECT_PREFIX = "pl";
 
   private final Set<IProcessor> processors;
 
   public ComponentDialect() {
-    super("Thymeleaf UI Component Dialect", DIALECT_PREFIX, 0);
+    this(DEFAULT_DIALECT_PREFIX);
+  }
+
+  public ComponentDialect(String prefix) {
+    super("Thymeleaf UI Component Dialect", prefix, 0);
 
     this.processors = new HashSet<>();
-    this.processors.add(new RemoveSlotAttributeProcessor(DIALECT_PREFIX, "slot"));
+    this.processors.add(new RemoveSlotAttributeProcessor(prefix, "slot"));
   }
 
   public ComponentDialect addComponent(String elementName, String templatePath) {
-    processors.add(new ComponentModelProcessor(DIALECT_PREFIX, elementName, templatePath));
-
+    processors.add(new ComponentModelProcessor(getPrefix (), elementName, templatePath));
     return this;
   }
 

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -26,6 +26,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.engine.TemplateManager;
 import org.thymeleaf.engine.TemplateModel;
@@ -159,8 +162,8 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
       List<ITemplateEvent> slotContent = slotContents.get(slotName);
 
       if (slotContent == null || slotContent.isEmpty()) {
-        if (slotElementTag instanceof IOpenElementTag) {
-          slotContent = fallbackSlotContent(fragmentModel, (IOpenElementTag) slotElementTag);
+        if (slotElementTag instanceof IOpenElementTag openElementTag) {
+          slotContent = fallbackSlotContent(fragmentModel, openElementTag);
         } else {
           slotContent = emptyList();
         }
@@ -194,8 +197,8 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
   }
 
   private boolean isSlot(ITemplateEvent templateEvent) {
-    if (templateEvent instanceof IProcessableElementTag) {
-      return ((IProcessableElementTag) templateEvent).getElementCompleteName().equals(dialectPrefix + ":slot");
+    if (templateEvent instanceof IProcessableElementTag elementTag) {
+      return elementTag.getElementCompleteName().equals(dialectPrefix + ":slot");
     }
 
     return false;
@@ -212,16 +215,16 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
   }
 
   private static IProcessableElementTag firstOpenOrStandaloneElementTag(IModel model) {
-    return templateEventsIn(model).stream()
-      .filter((elementTag) -> elementTag instanceof IProcessableElementTag)
+    return templateEventsIn(model)
+      .filter(elementTag -> elementTag instanceof IProcessableElementTag)
       .map(templateEvent -> (IProcessableElementTag)templateEvent)
       .findFirst()
       .orElse(null);
   }
 
   private static IProcessableElementTag firstOpenElementTagWithAttribute(IModel model, String attributeName) {
-    return templateEventsIn(model).stream()
-      .filter((elementTag) -> elementTag instanceof IOpenElementTag)
+    return templateEventsIn(model)
+      .filter(elementTag -> elementTag instanceof IOpenElementTag)
       .map(templateEvent -> (IProcessableElementTag)templateEvent)
       .filter(elementTag -> elementTag.hasAttribute(attributeName))
       .findFirst()
@@ -319,13 +322,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     return subTree;
   }
 
-  private static List<ITemplateEvent> templateEventsIn(IModel model) {
-    List<ITemplateEvent> templateEvents = new ArrayList<>();
-
-    for (int i = 0; i < model.size(); i++) {
-      templateEvents.add(model.get(i));
-    }
-
-    return templateEvents;
+  private static Stream<ITemplateEvent> templateEventsIn(IModel model) {
+    return IntStream.range(0, model.size()).mapToObj (model::get);
   }
 }

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -55,7 +55,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
 
     this.dialectPrefix = dialectPrefix;
     this.elementName = elementName;
-    this.templatePath = templatePath;
+    this.templatePath = templatePath != null ? templatePath : dialectPrefix + "/" + elementName + "/" + elementName;
   }
 
   @Override
@@ -90,7 +90,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
   }
 
   private IModel loadFragmentModel(ITemplateContext context) {
-    return parseFragmentTemplateModel(context, templatePath != null ? templatePath : "pl/" + elementName + "/" + elementName);
+    return parseFragmentTemplateModel(context, templatePath);
   }
 
   private Map<String, List<ITemplateEvent>> extractSlotContents(IModel model) {

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -81,6 +81,14 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withPassAdditionalAttributes_additionalDynamicAttribute_rendersAttribute() {
+    String html = render("<pl:with-pass-additional-attributes th:attr='key=value' />");
+
+    assertMarkupEquals("<i key=\"value\">has-additional-attributes</i>" +
+                       "<b key=\"value\">also-has-additional-attributes</b>", html);
+  }
+
+  @Test
   void simple_ifConditionTrue_renders() {
     String html = render("<pl:simple th:if='true' />");
 
@@ -450,6 +458,7 @@ class ComponentModelProcessorTest {
         .addComponent("simple", "components/simple.html")
         .addComponent("with-parameter", "components/with-parameter.html")
         .addComponent("with-variable", "components/with-variable.html")
+        .addComponent("with-pass-additional-attributes", "components/with-pass-additional-attributes.html")
         .addComponent("with-default-value", "components/with-default-value.html")
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")
         .addComponent("with-default-slot", "components/with-default-slot.html")

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -120,6 +120,27 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withVariable_variableDefinedAsParameter_rendersVariable() {
+    String html = render("<pl:with-variable pl:variable='|with-variable-defined:${variable}|' />");
+
+    assertMarkupEquals("<i>with-variable-defined:null</i>", html);
+  }
+
+  @Test
+  void withVariable_variableDefinedAsByWith_rendersVariable() {
+    String html = render("<pl:with-variable th:with='variable=|with-variable-defined:${variable}|' />");
+
+    assertMarkupEquals("<i>with-variable-defined:null</i>", html);
+  }
+
+  @Test
+  void withVariable_variableNotDefined_renders() {
+    String html = render("<pl:with-variable />");
+
+    assertMarkupEquals("<i></i>", html);
+  }
+
+  @Test
   void withDefaultSlot_slotContentDefined_rendersSlotContent() {
     String html = render(""
         + "<pl:with-default-slot>"
@@ -398,6 +419,7 @@ class ComponentModelProcessorTest {
     ComponentDialect componentDialect = new ComponentDialect()
         .addComponent("simple", "components/simple.html")
         .addComponent("with-parameter", "components/with-parameter.html")
+        .addComponent("with-variable", "components/with-variable.html")
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")
         .addComponent("with-default-slot", "components/with-default-slot.html")
         .addComponent("with-named-slots", "components/with-named-slots.html")

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -140,6 +140,36 @@ class ComponentModelProcessorTest {
     assertMarkupEquals("<i></i>", html);
   }
 
+
+  @Test
+  void withDefaultValue_variableDefinedAsParameter_rendersProvidedVariable() {
+    String html = render("<pl:with-default-value pl:variable='|with-variable-defined:${variable}|' />");
+
+    assertMarkupEquals("<i>with-variable-defined:null</i>", html);
+  }
+
+
+  @Test
+  void withDefaultValue_variableDefinedAsByWithOnParentTag_defaultValue() {
+    String html = render("<th:block th:with='variable=|with-variable-defined:${variable}|'><pl:with-default-value /></th:block>");
+
+    assertMarkupEquals("<i>default-value</i>", html);
+  }
+
+  @Test
+  void withDefaultValue_variableDefinedAsByWithOnSameTag_rendersProvidedVariableWithDefaultValuePredefined() {
+    String html = render("<pl:with-default-value th:with='variable=|with-variable-defined:${variable}|' />");
+
+    assertMarkupEquals("<i>with-variable-defined:default-value</i>", html);
+  }
+
+  @Test
+  void withDefaultValue_variableNotDefined_rendersDefaultValue() {
+    String html = render("<pl:with-default-value />");
+
+    assertMarkupEquals("<i>default-value</i>", html);
+  }
+
   @Test
   void withDefaultSlot_slotContentDefined_rendersSlotContent() {
     String html = render(""
@@ -420,6 +450,7 @@ class ComponentModelProcessorTest {
         .addComponent("simple", "components/simple.html")
         .addComponent("with-parameter", "components/with-parameter.html")
         .addComponent("with-variable", "components/with-variable.html")
+        .addComponent("with-default-value", "components/with-default-value.html")
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")
         .addComponent("with-default-slot", "components/with-default-slot.html")
         .addComponent("with-named-slots", "components/with-named-slots.html")

--- a/src/test/resources/components/with-default-value.html
+++ b/src/test/resources/components/with-default-value.html
@@ -1,0 +1,3 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-variable()" pl:variable="default-value">
+  <i th:text="${variable}"></i>
+</th:block>

--- a/src/test/resources/components/with-pass-additional-attributes.html
+++ b/src/test/resources/components/with-pass-additional-attributes.html
@@ -1,0 +1,4 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="simple()">
+  <i pl:pass-additional-attributes>has-additional-attributes</i>
+  <b pl:pass-additional-attributes>also-has-additional-attributes</b>
+</th:block>

--- a/src/test/resources/components/with-variable.html
+++ b/src/test/resources/components/with-variable.html
@@ -1,0 +1,3 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-variable()">
+  <i th:text="${variable}"></i>
+</th:block>


### PR DESCRIPTION
- change the dialect-prefix via the constructor `ComponentDialect(String prefix)`:
  this allows to put components in different namespaces by defining different dialects
- define default-values for attributes:
  Default values for attributes can be defined on the component-fragment with `pl:nameOfTheAttribute=${...}`.
  When this attribute is not provided by the caller (also via `pl:nameOfTheAttribute=${...}`), the default value is used.
  ```html
  <th:block xmlns:th="http://www.thymeleaf.org" th:fragment="card(title)" pl:subtitle="${null}">
    ...
  ```
  In contrast to ussing the existing mechanisms of thymeleaf (`th:with=` and `${variable ?: 'default'}`), the default-attributes have the advantage, to not inherit the variables from the caller scope, and to reset the attribute to the default when not directly specified by the caller.
- place `pl:pass-additional-attributes` on to an element inside the template (usually the root) to pass each additional attribute (not having the prefix `pl:`) to this element. If there is no `pl:pass-additional-attributes` inside the template, a virtual `<th:block>` is creted, that will get th eadditional attributes.