### PR TITLE
feat(additional-attributes): add test for "additional static attributes and remove old disabled tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,41 @@ Do the same accordingly for the other components.
 </pl:card>
 ```
 
+### Checking if a slot is defined
+
+Inside a component template, you can check whether the caller provided content for a slot using the `#pl` expression object.
+This allows conditional rendering based on whether slot content was supplied.
+
+Check the **default slot**:
+
+```html
+<div th:if="${#pl.defaultSlotDefined}">
+  <!-- rendered only when caller provides default slot content -->
+  <pl:slot/>
+</div>
+```
+
+Check a **named slot** by name:
+
+```html
+<div th:if="${#pl.isSlotDefined('footer')}">
+  <pl:slot pl:name="footer"/>
+</div>
+```
+
+The expression object name matches the dialect prefix (`pl` by default). When registering the dialect with a custom prefix,
+the expression object is accessible under that same prefix:
+
+```java
+new ComponentDialect("ui") // expression object becomes #ui
+```
+
+You can also provide a separate name for the expression object:
+
+```java
+new ComponentDialect("ui", "component") // expression object becomes #component
+```
+
 ## License
 
 Thymeleaf Component Dialect is Open Source software released under the

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
@@ -34,6 +34,7 @@ public class ComponentDialect extends AbstractProcessorDialect {
     super("Thymeleaf UI Component Dialect", prefix, 0);
 
     this.processors = new HashSet<>();
+    this.processors.add(new ReplaceSlotTagProcessor(prefix, "slot"));
     this.processors.add(new RemoveSlotAttributeProcessor(prefix, "slot"));
   }
 

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
@@ -18,23 +18,31 @@ package ch.cstettler.thymeleaf;
 import java.util.HashSet;
 import java.util.Set;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
+import org.thymeleaf.dialect.IExpressionObjectDialect;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.standard.StandardDialect;
 import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor;
 import org.thymeleaf.templatemode.TemplateMode;
 
-public class ComponentDialect extends AbstractProcessorDialect {
+public class ComponentDialect extends AbstractProcessorDialect implements IExpressionObjectDialect {
 
   private static final String DEFAULT_DIALECT_PREFIX = "pl";
 
   private final Set<IProcessor> processors;
+  private final ComponentExpressionObjectFactory expressionObjectFactory;
 
   public ComponentDialect() {
     this(DEFAULT_DIALECT_PREFIX);
   }
 
   public ComponentDialect(String prefix) {
+    this(prefix, prefix);
+  }
+
+  public ComponentDialect(String prefix, String expressionObjectName) {
     super("Thymeleaf UI Component Dialect", prefix, StandardDialect.PROCESSOR_PRECEDENCE);
+
+    this.expressionObjectFactory = new ComponentExpressionObjectFactory (expressionObjectName);
 
     this.processors = new HashSet<>();
     this.processors.add (new StandardXmlNsTagProcessor (TemplateMode.HTML, prefix));
@@ -50,5 +58,10 @@ public class ComponentDialect extends AbstractProcessorDialect {
   @Override
   public Set<IProcessor> getProcessors(String dialectPrefix) {
     return processors;
+  }
+
+  @Override
+  public ComponentExpressionObjectFactory getExpressionObjectFactory () {
+    return expressionObjectFactory;
   }
 }

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentDialect.java
@@ -19,6 +19,9 @@ import java.util.HashSet;
 import java.util.Set;
 import org.thymeleaf.dialect.AbstractProcessorDialect;
 import org.thymeleaf.processor.IProcessor;
+import org.thymeleaf.standard.StandardDialect;
+import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor;
+import org.thymeleaf.templatemode.TemplateMode;
 
 public class ComponentDialect extends AbstractProcessorDialect {
 
@@ -31,9 +34,10 @@ public class ComponentDialect extends AbstractProcessorDialect {
   }
 
   public ComponentDialect(String prefix) {
-    super("Thymeleaf UI Component Dialect", prefix, 0);
+    super("Thymeleaf UI Component Dialect", prefix, StandardDialect.PROCESSOR_PRECEDENCE);
 
     this.processors = new HashSet<>();
+    this.processors.add (new StandardXmlNsTagProcessor (TemplateMode.HTML, prefix));
     this.processors.add(new ReplaceSlotTagProcessor(prefix, "slot"));
     this.processors.add(new RemoveSlotAttributeProcessor(prefix, "slot"));
   }

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentExpressionObject.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentExpressionObject.java
@@ -1,0 +1,29 @@
+package ch.cstettler.thymeleaf;
+
+import org.thymeleaf.context.IExpressionContext;
+
+public class ComponentExpressionObject {
+
+  private final IExpressionContext context;
+
+  ComponentExpressionObject(IExpressionContext context) {
+    this.context = context;
+  }
+
+  private ReplaceSlotTagProcessor.SlotData getSlotData() {
+    if (context.getVariable(ReplaceSlotTagProcessor.SLOTS_DATA) instanceof ReplaceSlotTagProcessor.SlotData slotData) {
+      return slotData;
+    } else {
+      return null;
+    }
+  }
+
+  public boolean isDefaultSlotDefined() {
+    return isSlotDefined (ReplaceSlotTagProcessor.DEFAULT_SLOT_NAME);
+  }
+
+  public boolean isSlotDefined(String slotName) {
+    ReplaceSlotTagProcessor.SlotData slotData = getSlotData();
+    return slotData != null && slotData.contains (slotName);
+  }
+}

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentExpressionObjectFactory.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentExpressionObjectFactory.java
@@ -1,0 +1,34 @@
+package ch.cstettler.thymeleaf;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.thymeleaf.context.IExpressionContext;
+import org.thymeleaf.expression.IExpressionObjectFactory;
+
+public class ComponentExpressionObjectFactory implements IExpressionObjectFactory {
+
+  private final String objectName;
+
+  ComponentExpressionObjectFactory(String objectName) {
+    this.objectName = objectName;
+  }
+
+  @Override
+  public Set<String> getAllExpressionObjectNames() {
+    return objectName == null || objectName.isEmpty () ? Collections.emptySet () : Collections.singleton (objectName);
+  }
+
+  @Override
+  public Object buildObject(IExpressionContext context, String expressionObjectName) {
+    if (objectName.equals(expressionObjectName)) {
+      return new ComponentExpressionObject (context);
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isCacheable(String expressionObjectName) {
+    return false;
+  }
+}

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -293,8 +293,8 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
         .filter(attribute -> dialectPrefix.equals(attribute.getAttributeDefinition().getAttributeName().getPrefix()))
         .forEach(attribute -> {
           Object resolvedValue = tryResolveAttributeValue(attribute, context, expressionParser);
-
-          attributes.put(attribute.getAttributeCompleteName().substring(dialectPrefix.length() + 1), resolvedValue);
+          String attributeName = kebabToCamelCase(attribute.getAttributeDefinition().getAttributeName().getAttributeName());
+          attributes.put(attributeName, resolvedValue);
         });
     }
 
@@ -384,5 +384,23 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
 
   private static Stream<ITemplateEvent> templateEventsIn(IModel model) {
     return IntStream.range(0, model.size()).mapToObj (model::get);
+  }
+
+  private static String kebabToCamelCase(String kebabCase) {
+    StringBuilder camelCase = new StringBuilder();
+    boolean toUpperCase = false;
+    for (char c : kebabCase.toCharArray()) {
+      if (c == '-') {
+        toUpperCase = true;
+      } else {
+        if (toUpperCase) {
+          camelCase.append(Character.toUpperCase(c));
+          toUpperCase = false;
+        } else {
+          camelCase.append(c);
+        }
+      }
+    }
+    return camelCase.toString();
   }
 }

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -85,7 +85,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     Map<String, Object> componentAttributes = resolveComponentAttributes(componentElementTag, context, expressionParser);
     componentAttributes.forEach(structureHandler::setLocalVariable);
 
-    IModel fragmentModel = loadFragmentModel(context);
+    TemplateModel fragmentModel = loadFragmentModel(context);
     IProcessableElementTag fragmentRootElementTag = firstOpenElementTagWithAttribute(fragmentModel, TH_FRAGMENT);
     if (fragmentRootElementTag != null) {
       Map<String, Object> defaultAttributes = resolveComponentAttributes (fragmentRootElementTag, context, expressionParser);
@@ -110,6 +110,13 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
         }
       }
     }
+
+    /*
+     * APPLY THE FRAGMENT'S TEMPLATE RESOLUTION so that all code inside the fragment is executed with its own
+     * template resolution info (working as if it were a local variable)
+     */
+    structureHandler.setTemplateData(fragmentModel.getTemplateData());
+
     Map<String, List<ITemplateEvent>> slotContents = extractSlotContents(model);
     Map<String, ITemplateEvent> slots = extractSlots(fragmentModel);
     IModel mergedModel = prepareModel(context, fragmentModel, fragmentRootElementTag, additionalAttributes, slots, slotContents);
@@ -122,7 +129,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     return componentElementTag.getElementCompleteName().startsWith(dialectPrefix + ":");
   }
 
-  private IModel loadFragmentModel(ITemplateContext context) {
+  private TemplateModel loadFragmentModel(ITemplateContext context) {
     return parseFragmentTemplateModel(context, templatePath);
   }
 
@@ -359,7 +366,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     }
   }
 
-  private static IModel parseFragmentTemplateModel(ITemplateContext context, String templateName) {
+  private static TemplateModel parseFragmentTemplateModel(ITemplateContext context, String templateName) {
     TemplateManager templateManager = context.getConfiguration().getTemplateManager();
     TemplateModel templateModel = templateManager.parseStandalone(context, templateName, emptySet(), HTML, true, true);
 

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -18,7 +18,6 @@ package ch.cstettler.thymeleaf;
 import static java.util.Arrays.stream;
 import static java.util.Collections.*;
 import static org.thymeleaf.model.AttributeValueQuotes.DOUBLE;
-import static org.thymeleaf.standard.processor.StandardReplaceTagProcessor.PRECEDENCE;
 import static org.thymeleaf.templatemode.TemplateMode.HTML;
 
 import java.util.ArrayList;
@@ -51,6 +50,13 @@ import org.thymeleaf.util.StringUtils;
 
 class ComponentModelProcessor extends AbstractElementModelProcessor {
 
+  /*
+   * Execute between `th:with` (precedence=600) and `th:attr` (precedence=700).
+   * This means, attributes like th:if or th:each will be executed before the component is processed, but attributes like th:attr will be executed after.
+   * This allows to use for example `th:if`, `th:each` on the component tag, but allows to use th:attr to be passed down using `pass-additional-attributes`.
+   * And `th:object` and `th:with` can be used on the component tag to define variables that are available in the slots, and not affected by pass-additional-attributes.
+   */
+  public static final int PRECEDENCE = 650;
   private static final String TH_FRAGMENT = "th:fragment";
 
   private final String dialectPrefix;

--- a/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ComponentModelProcessor.java
@@ -90,7 +90,7 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     }
     IEngineConfiguration configuration = context.getConfiguration();
     IStandardExpressionParser expressionParser = StandardExpressions.getExpressionParser(configuration);
-    Map<String, Object> additionalAttributes = resolveAdditionalAttributes(componentElementTag, context, expressionParser);
+    Map<String, Object> additionalAttributes = getAdditionalAttributes (componentElementTag);
     Map<String, Object> componentAttributes = resolveComponentAttributes(componentElementTag, context, expressionParser);
     componentAttributes.forEach(structureHandler::setLocalVariable);
 
@@ -301,15 +301,13 @@ class ComponentModelProcessor extends AbstractElementModelProcessor {
     return attributes;
   }
 
-  private Map<String, Object> resolveAdditionalAttributes(IProcessableElementTag element, ITemplateContext context,
-    IStandardExpressionParser expressionParser) {
+  private Map<String, Object> getAdditionalAttributes (IProcessableElementTag element) {
     Map<String, Object> attributes = new HashMap<>();
 
     if (element.getAllAttributes() != null) {
       stream(element.getAllAttributes())
         .filter(attribute -> !dialectPrefix.equals(attribute.getAttributeDefinition().getAttributeName().getPrefix()))
-        .forEach(attribute -> attributes.put(attribute.getAttributeCompleteName(),
-          tryResolveAttributeValue(attribute, context, expressionParser)));
+        .forEach(attribute -> attributes.put(attribute.getAttributeCompleteName(), attribute.getValue ()));
     }
 
     return attributes;

--- a/src/main/java/ch/cstettler/thymeleaf/ReplaceSlotTagProcessor.java
+++ b/src/main/java/ch/cstettler/thymeleaf/ReplaceSlotTagProcessor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 Christian Stettler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.cstettler.thymeleaf;
+
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.engine.TemplateData;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.model.IProcessableElementTag;
+import org.thymeleaf.processor.element.AbstractElementTagProcessor;
+import org.thymeleaf.processor.element.IElementTagStructureHandler;
+
+import java.util.Map;
+
+import static org.thymeleaf.standard.processor.StandardReplaceTagProcessor.PRECEDENCE;
+import static org.thymeleaf.templatemode.TemplateMode.HTML;
+
+class ReplaceSlotTagProcessor extends AbstractElementTagProcessor {
+
+    static final String DEFAULT_SLOT_NAME = ReplaceSlotTagProcessor.class.getName() + ".default";
+    static final String SLOTS_DATA = ReplaceSlotTagProcessor.class.getName() + ".slots-data";
+
+    private final String dialectPrefix;
+
+    public ReplaceSlotTagProcessor(String dialectPrefix, String elementName) {
+        super(HTML, dialectPrefix, elementName, true, null, false, PRECEDENCE);
+        this.dialectPrefix = dialectPrefix;
+    }
+
+    @Override
+    protected void doProcess(ITemplateContext context, IProcessableElementTag tag, IElementTagStructureHandler structureHandler) {
+        String slotName = tag.hasAttribute(dialectPrefix, "name") ? tag.getAttributeValue(dialectPrefix, "name") : DEFAULT_SLOT_NAME;
+
+        Object slotsDataObj = context.getVariable(SLOTS_DATA);
+        if (slotsDataObj instanceof SlotData slotsData && slotsData.contains(slotName)) {
+            IModel model = slotsData.get(slotName);
+            if (model != null) {
+                structureHandler.setLocalVariable(SLOTS_DATA, slotsData.parent);
+                structureHandler.setTemplateData(slotsData.templateData);
+                structureHandler.replaceWith(model, true);
+            } else {
+                // remove the <pl:slot> tag, as no content was provided for this slot
+                structureHandler.removeElement();
+            }
+        } else {
+            // remove the <pl:slot> tag, but keep its original body
+            structureHandler.removeTags();
+        }
+    }
+
+    record SlotData(Map<String, IModel> slotsMap, TemplateData templateData, SlotData parent) {
+        SlotData(Map<String, IModel> slotsMap, TemplateData templateData) {
+            this(slotsMap, templateData, null);
+        }
+
+        boolean contains(String slotName) {
+            return slotsMap.containsKey(slotName);
+        }
+
+        IModel get(String slotName) {
+            return slotsMap.get(slotName);
+        }
+    }
+}

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -305,6 +305,19 @@ class ComponentModelProcessorTest {
     assertMarkupEquals("<b>bar</b>", html);
   }
 
+  @Test
+  void withSlotConditional_replacesTheCorrectSlot_True() {
+    String html = render("<pl:with-slot-conditional pl:condition='${true}'></pl:with-slot-conditional>");
+
+    assertMarkupEquals("<div><i>True</i><p>fallback 1</p></div>", html);
+  }
+
+  @Test
+  void withSlotConditional_replacesTheCorrectSlot_False() {
+    String html = render("<pl:with-slot-conditional pl:condition='${false}'></pl:with-slot-conditional>");
+
+    assertMarkupEquals("<div><i>False</i><p>fallback 2</p></div>", html);
+  }
 
   @Test
   void subTree_rootStartTemplateEvent_returnsCompleteTree() {
@@ -462,7 +475,8 @@ class ComponentModelProcessorTest {
         .addComponent("with-named-slots", "components/with-named-slots.html")
         .addComponent("with-slot-with-fallback", "components/with-slot-with-fallback.html")
         .addComponent("with-nested-fragment", "components/with-nested-fragment.html")
-        .addComponent("with-nested-fragment-other", "components/with-nested-fragment.html :: other-fragment");
+        .addComponent("with-nested-fragment-other", "components/with-nested-fragment.html :: other-fragment")
+        .addComponent("with-slot-conditional", "components/with-slot-conditional.html");
 
     TemplateEngine templateEngine = new TemplateEngine();
     templateEngine.setTemplateResolvers(setOf(new TemplateResolverChain(new ClassLoaderTemplateResolver(), new StringTemplateResolver())));

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -299,6 +299,14 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withNestedFragment_correctFragmentForComponent() {
+    String html = render("<pl:with-nested-fragment-other pl:variable='bar'></pl:with-nested-fragment-other>");
+
+    assertMarkupEquals("<b>bar</b>", html);
+  }
+
+
+  @Test
   void subTree_rootStartTemplateEvent_returnsCompleteTree() {
     ITemplateEvent startTemplateEvent = openElementTag();
     List<ITemplateEvent> templateEvents = List.of(
@@ -453,7 +461,8 @@ class ComponentModelProcessorTest {
         .addComponent("with-default-slot", "components/with-default-slot.html")
         .addComponent("with-named-slots", "components/with-named-slots.html")
         .addComponent("with-slot-with-fallback", "components/with-slot-with-fallback.html")
-        .addComponent("with-nested-fragment", "components/with-nested-fragment.html");
+        .addComponent("with-nested-fragment", "components/with-nested-fragment.html")
+        .addComponent("with-nested-fragment-other", "components/with-nested-fragment.html :: other-fragment");
 
     TemplateEngine templateEngine = new TemplateEngine();
     templateEngine.setTemplateResolvers(setOf(new TemplateResolverChain(new ClassLoaderTemplateResolver(), new StringTemplateResolver())));

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -15,34 +15,24 @@
  */
 package ch.cstettler.thymeleaf;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.TemplateSpec;
 import org.thymeleaf.context.Context;
-import org.thymeleaf.model.ICloseElementTag;
-import org.thymeleaf.model.IModel;
-import org.thymeleaf.model.IOpenElementTag;
-import org.thymeleaf.model.IStandaloneElementTag;
-import org.thymeleaf.model.ITemplateEnd;
-import org.thymeleaf.model.ITemplateEvent;
-import org.thymeleaf.model.ITemplateStart;
-import org.thymeleaf.model.IText;
+import org.thymeleaf.exceptions.TemplateInputException;
+import org.thymeleaf.model.*;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 import org.thymeleaf.templateresolver.StringTemplateResolver;
 import org.thymeleaf.templateresolver.TemplateResolution;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -113,10 +103,10 @@ class ComponentModelProcessorTest {
   }
 
   @Test
-  void withParameter_parameterNotDefined_renders() {
-    String html = render("<pl:with-parameter />");
-
-    assertMarkupEquals("<i></i>", html);
+  void withParameter_requiredParameterNotDefined_fails() {
+    assertThrows(TemplateInputException.class, () -> {
+      render("<pl:with-parameter />");
+    });
   }
 
   @Test

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -64,20 +64,12 @@ class ComponentModelProcessorTest {
     assertMarkupEquals("<i>simple</i>", html);
   }
 
-  @Disabled("additional attributes not yet fully supported")
   @Test
-  void simple_additionalStaticAttribute_rendersAttribute() {
-    String html = render("<pl:simple key='value' />");
+  void withPassAdditionalAttributes_additionalStaticAttribute_rendersAttribute() {
+    String html = render("<pl:with-pass-additional-attributes key='value' />");
 
-    assertMarkupEquals("<i key='value'>simple</i>", html);
-  }
-
-  @Disabled("additional attributes not yet fully supported")
-  @Test
-  void simple_additionalDynamicAttribute_rendersAttribute() {
-    String html = render("<pl:simple th:attr='key=value' />");
-
-    assertMarkupEquals("<i key='value'>simple</i>", html);
+    assertMarkupEquals("<i key=\"value\">has-additional-attributes</i>" +
+        "<b key=\"value\">also-has-additional-attributes</b>", html);
   }
 
   @Test

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -292,6 +292,13 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withNestedFragment_resolvesInnerFragment() {
+    String html = render("<pl:with-nested-fragment pl:variable='bar'></pl:with-nested-fragment>");
+
+    assertMarkupEquals("<i>bar</i><span><b>bar</b></span>", html);
+  }
+
+  @Test
   void subTree_rootStartTemplateEvent_returnsCompleteTree() {
     ITemplateEvent startTemplateEvent = openElementTag();
     List<ITemplateEvent> templateEvents = List.of(
@@ -445,7 +452,8 @@ class ComponentModelProcessorTest {
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")
         .addComponent("with-default-slot", "components/with-default-slot.html")
         .addComponent("with-named-slots", "components/with-named-slots.html")
-        .addComponent("with-slot-with-fallback", "components/with-slot-with-fallback.html");
+        .addComponent("with-slot-with-fallback", "components/with-slot-with-fallback.html")
+        .addComponent("with-nested-fragment", "components/with-nested-fragment.html");
 
     TemplateEngine templateEngine = new TemplateEngine();
     templateEngine.setTemplateResolvers(setOf(new TemplateResolverChain(new ClassLoaderTemplateResolver(), new StringTemplateResolver())));

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -130,6 +130,12 @@ class ComponentModelProcessorTest {
     assertMarkupEquals("<i></i>", html);
   }
 
+  @Test
+  void withVariableCamelCase_variableDefinedAsParameter_rendersVariable() {
+    String html = render("<pl:with-variable-camelCase pl:variable-camel-case='|with-variable-defined:${variableCamelCase}|' />");
+
+    assertMarkupEquals("<i>with-variable-defined:null</i>", html);
+  }
 
   @Test
   void withDefaultValue_variableDefinedAsParameter_rendersProvidedVariable() {
@@ -468,6 +474,7 @@ class ComponentModelProcessorTest {
         .addComponent("simple", "components/simple.html")
         .addComponent("with-parameter", "components/with-parameter.html")
         .addComponent("with-variable", "components/with-variable.html")
+        .addComponent("with-variable-camelCase", "components/with-variable-camelCase.html")
         .addComponent("with-pass-additional-attributes", "components/with-pass-additional-attributes.html")
         .addComponent("with-default-value", "components/with-default-value.html")
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -112,10 +112,30 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void simple_each_rendersMulti() {
+    Context context = new Context ();
+    context.setVariable("items", List.of("item1", "item2", "item3"));
+
+    String html = render("<pl:simple th:each='item:${items}' />", context);
+
+    assertMarkupEquals("<i>simple</i><i>simple</i><i>simple</i>", html);
+  }
+
+  @Test
   void withParameter_parameterDefined_rendersParameter() {
     String html = render("<pl:with-parameter pl:parameter='with-parameter-defined' />");
 
     assertMarkupEquals("<i>with-parameter-defined</i>", html);
+  }
+
+  @Test
+  void withParameter_each_rendersParameter() {
+    Context context = new Context ();
+    context.setVariable("items", List.of("item1", "item2", "item3"));
+
+    String html = render("<pl:with-parameter th:each='item:${items}' pl:parameter='${item}' />", context);
+
+    assertMarkupEquals("<i>item1</i><i>item2</i><i>item3</i>", html);
   }
 
   @Test
@@ -166,13 +186,6 @@ class ComponentModelProcessorTest {
     String html = render("<th:block th:with='variable=|with-variable-defined:${variable}|'><pl:with-default-value /></th:block>");
 
     assertMarkupEquals("<i>default-value</i>", html);
-  }
-
-  @Test
-  void withDefaultValue_variableDefinedAsByWithOnSameTag_rendersProvidedVariableWithDefaultValuePredefined() {
-    String html = render("<pl:with-default-value th:with='variable=|with-variable-defined:${variable}|' />");
-
-    assertMarkupEquals("<i>with-variable-defined:default-value</i>", html);
   }
 
   @Test
@@ -342,6 +355,42 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withPassAdditionalAttributesAnsSlot_withDefaultSlotValue_rendersAdditionalAttribute() {
+    String html = render("<pl:with-pass-additional-attributes-and-slot th:title=\"${'the title'}\"></pl:with-pass-additional-attributes-and-slot>");
+
+    assertMarkupEquals(""
+                       + "<i title=\"the title\">has-additional-attributes</i>"
+                       +"<b>And Slot (default)</b>", html);
+  }
+
+  @Test
+  void withPassAdditionalAttributesAnsSlot_withValueInSlot_resolvesValue() {
+    String html = render("<pl:with-pass-additional-attributes-and-slot th:title=\"${'the title'}\" th:with=\"theValue=${'a value'}\">" +
+                         "<b>And Slot with <th:block th:text='${theValue}'></th:block></b>" +
+                         "</pl:with-pass-additional-attributes-and-slot>");
+
+    assertMarkupEquals(""
+                       + "<i title=\"the title\">has-additional-attributes</i>"
+                       +"<b>And Slot with a value</b>", html);
+  }
+
+  @Test
+  void withPassAdditionalAttributesAnsSlot_ifConditionTrue_renders() {
+    String html = render("<pl:with-pass-additional-attributes-and-slot th:title=\"${'the title'}\" th:if=\"true\"></pl:with-pass-additional-attributes-and-slot>");
+
+    assertMarkupEquals(""
+                       + "<i title=\"the title\">has-additional-attributes</i>"
+                       +"<b>And Slot (default)</b>", html);
+  }
+
+  @Test
+  void withPassAdditionalAttributesAnsSlot_ifConditionFalse_rendersNothing() {
+    String html = render("<pl:with-pass-additional-attributes-and-slot th:title=\"${'the title'}\" th:if=\"false\"></pl:with-pass-additional-attributes-and-slot>");
+
+    assertMarkupEquals("", html);
+  }
+
+  @Test
   void subTree_rootStartTemplateEvent_returnsCompleteTree() {
     ITemplateEvent startTemplateEvent = openElementTag();
     List<ITemplateEvent> templateEvents = List.of(
@@ -486,12 +535,17 @@ class ComponentModelProcessorTest {
   }
 
   private static String render(String template) {
+    return render(template, new Context());
+  }
+
+  private static String render(String template, Context context) {
     ComponentDialect componentDialect = new ComponentDialect()
         .addComponent("simple", "components/simple.html")
         .addComponent("with-parameter", "components/with-parameter.html")
         .addComponent("with-variable", "components/with-variable.html")
         .addComponent("with-variable-camelCase", "components/with-variable-camelCase.html")
         .addComponent("with-pass-additional-attributes", "components/with-pass-additional-attributes.html")
+        .addComponent("with-pass-additional-attributes-and-slot", "components/with-pass-additional-attributes-and-slot.html")
         .addComponent("with-default-value", "components/with-default-value.html")
         .addComponent("with-default-and-named-slots", "components/with-default-and-named-slots.html")
         .addComponent("with-default-slot", "components/with-default-slot.html")
@@ -507,7 +561,7 @@ class ComponentModelProcessorTest {
     templateEngine.setCacheManager(null);
     templateEngine.clearTemplateCache();
 
-    String result = templateEngine.process(new TemplateSpec(template, HTML), new Context());
+    String result = templateEngine.process(new TemplateSpec(template, HTML), context);
 
     return result.trim();
   }

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -71,6 +71,22 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withPassAdditionalAttributes_additionalDynamicAttribute2_rendersAttribute() {
+    String html = render("<pl:with-pass-additional-attributes th:attr=\"key=${'$value$'}\" />");
+
+    assertMarkupEquals("<i key=\"$value$\">has-additional-attributes</i>" +
+                       "<b key=\"$value$\">also-has-additional-attributes</b>", html);
+  }
+
+  @Test
+  void withPassAdditionalAttributes_additionalDynamicAttribute3_rendersAttribute() {
+    String html = render("<pl:with-pass-additional-attributes th:key=\"${'$value$'}\" />");
+
+    assertMarkupEquals("<i key=\"$value$\">has-additional-attributes</i>" +
+                       "<b key=\"$value$\">also-has-additional-attributes</b>", html);
+  }
+
+  @Test
   void simple_ifConditionTrue_renders() {
     String html = render("<pl:simple th:if='true' />");
 

--- a/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
+++ b/src/test/java/ch/cstettler/thymeleaf/ComponentModelProcessorTest.java
@@ -391,6 +391,34 @@ class ComponentModelProcessorTest {
   }
 
   @Test
+  void withSlotCheck_defaultSlotDefined_rendersSlotDefinedIndicator() {
+    String html = render("<pl:with-slot-check><i>content</i></pl:with-slot-check>");
+
+    assertMarkupEquals("<div><i>default-slot-defined</i><i>content</i></div>", html);
+  }
+
+  @Test
+  void withSlotCheck_defaultSlotNotDefined_rendersSlotNotDefinedIndicator() {
+    String html = render("<pl:with-slot-check></pl:with-slot-check>");
+
+    assertMarkupEquals("<div><i>default-slot-not-defined</i></div>", html);
+  }
+
+  @Test
+  void withNamedSlotCheck_namedSlotDefined_rendersSlotDefinedIndicator() {
+    String html = render("<pl:with-named-slot-check><i pl:slot='slot-a'>content</i></pl:with-named-slot-check>");
+
+    assertMarkupEquals("<div><i>slot-a-defined</i><i>content</i></div>", html);
+  }
+
+  @Test
+  void withNamedSlotCheck_namedSlotNotDefined_rendersSlotNotDefinedIndicator() {
+    String html = render("<pl:with-named-slot-check></pl:with-named-slot-check>");
+
+    assertMarkupEquals("<div><i>slot-a-not-defined</i></div>", html);
+  }
+
+  @Test
   void subTree_rootStartTemplateEvent_returnsCompleteTree() {
     ITemplateEvent startTemplateEvent = openElementTag();
     List<ITemplateEvent> templateEvents = List.of(
@@ -553,7 +581,9 @@ class ComponentModelProcessorTest {
         .addComponent("with-slot-with-fallback", "components/with-slot-with-fallback.html")
         .addComponent("with-nested-fragment", "components/with-nested-fragment.html")
         .addComponent("with-nested-fragment-other", "components/with-nested-fragment.html :: other-fragment")
-        .addComponent("with-slot-conditional", "components/with-slot-conditional.html");
+        .addComponent("with-slot-conditional", "components/with-slot-conditional.html")
+        .addComponent("with-slot-check", "components/with-slot-check.html")
+        .addComponent("with-named-slot-check", "components/with-named-slot-check.html");
 
     TemplateEngine templateEngine = new TemplateEngine();
     templateEngine.setTemplateResolvers(setOf(new TemplateResolverChain(new ClassLoaderTemplateResolver(), new StringTemplateResolver())));

--- a/src/test/resources/components/with-default-value.html
+++ b/src/test/resources/components/with-default-value.html
@@ -1,3 +1,3 @@
-<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-variable()" pl:variable="default-value">
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-default-value()" pl:variable="default-value">
   <i th:text="${variable}"></i>
 </th:block>

--- a/src/test/resources/components/with-named-slot-check.html
+++ b/src/test/resources/components/with-named-slot-check.html
@@ -1,0 +1,7 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-named-slot-check()">
+  <div>
+    <i th:if="${#pl.isSlotDefined('slot-a')}">slot-a-defined</i>
+    <i th:unless="${#pl.isSlotDefined('slot-a')}">slot-a-not-defined</i>
+    <pl:slot pl:name="slot-a"/>
+  </div>
+</th:block>

--- a/src/test/resources/components/with-nested-fragment.html
+++ b/src/test/resources/components/with-nested-fragment.html
@@ -1,0 +1,9 @@
+<th:block xmlns:th="http://www.thymeleaf.org">
+  <th:block  th:fragment="with-nested-fragment()">
+    <i th:text="${variable}"></i>
+    <span th:insert="~{::other-fragment}">test</span>
+  </th:block>
+  <th:block th:fragment="other-fragment">
+    <b th:text="${variable}"></b>
+  </th:block>
+</th:block>

--- a/src/test/resources/components/with-pass-additional-attributes-and-slot.html
+++ b/src/test/resources/components/with-pass-additional-attributes-and-slot.html
@@ -1,0 +1,6 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-pass-additional-attributes-and-slot()">
+  <i pl:pass-additional-attributes>has-additional-attributes</i>
+  <pl:slot>
+    <b>And Slot (default)</b>
+  </pl:slot>
+</th:block>

--- a/src/test/resources/components/with-pass-additional-attributes.html
+++ b/src/test/resources/components/with-pass-additional-attributes.html
@@ -1,4 +1,4 @@
-<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="simple()">
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-pass-additional-attributes()">
   <i pl:pass-additional-attributes>has-additional-attributes</i>
   <b pl:pass-additional-attributes>also-has-additional-attributes</b>
 </th:block>

--- a/src/test/resources/components/with-slot-check.html
+++ b/src/test/resources/components/with-slot-check.html
@@ -1,0 +1,7 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-slot-check()">
+  <div>
+    <i th:if="${#pl.defaultSlotDefined}">default-slot-defined</i>
+    <i th:unless="${#pl.defaultSlotDefined}">default-slot-not-defined</i>
+    <pl:slot/>
+  </div>
+</th:block>

--- a/src/test/resources/components/with-slot-conditional.html
+++ b/src/test/resources/components/with-slot-conditional.html
@@ -1,0 +1,14 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-slot-conditional()">
+  <div th:if="${condition}">
+    <i>True</i>
+    <pl:slot>
+      <p>fallback 1</p>
+    </pl:slot>
+  </div>
+  <div th:unless="${condition}">
+    <i>False</i>
+    <pl:slot>
+      <p>fallback 2</p>
+    </pl:slot>
+  </div>
+</th:block>

--- a/src/test/resources/components/with-variable-camelCase.html
+++ b/src/test/resources/components/with-variable-camelCase.html
@@ -1,0 +1,3 @@
+<th:block xmlns:th="http://www.thymeleaf.org" th:fragment="with-variable-camelCase()">
+  <i th:text="${variableCamelCase}"></i>
+</th:block>


### PR DESCRIPTION
- removed disabled tests.
  replaced by new tests, that use the explicit `pl:pass-additional-attributes` attribute
- pick correct fragment in file, and validate signature (required parameters inside `()`)
  (similar like `th:insert` and `th:replace` works)
- set TemplateData to allow to correctly resolve relative templates (`~{::fragment-name}`)
- use seperate tag-processor for replacing slots. 
  more roboust: only slots that survive evaluation (`th:if`) are replaced; 